### PR TITLE
Replace compute target with a structure map function

### DIFF
--- a/sintr_worker/bin/workTarget/worker_isolate.dart
+++ b/sintr_worker/bin/workTarget/worker_isolate.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:isolate';
 
 main(List<String> args, SendPort sendPort) {
@@ -13,6 +14,18 @@ main(List<String> args, SendPort sendPort) {
   });
 }
 
+
 _handle(String msg) {
-  return "ECHO: $msg";
+  // Unpack arguments
+
+  var inArgs = JSON.decode(msg);
+
+  String key = inArgs["key"];
+  String value = inArgs["value"];
+
+  return JSON.encode(map(key, value));
+}
+
+Map<String, List<String>> map(String k, String v) {
+  return { k : [ v.length ] };
 }


### PR DESCRIPTION
@danrubel TBR

This replaces the target code, with a MR function. As a client of Sintr, the simplest thing to do is to implement one of these map functions.