### PR TITLE
Ignore .pub files in deployment

### DIFF
--- a/tools/scripts/deploy_image.sh
+++ b/tools/scripts/deploy_image.sh
@@ -7,7 +7,7 @@
 
 # Run this script from the root of the sintr project
 
-tar -cz --exclude="packages" -f sintr-image.tar.gz sintr_*
+tar -cz --exclude="packages" --exclude=".pub" -f sintr-image.tar.gz sintr_*
 
 # Uncomment to enable upload to cloud location
 gsutil mv sintr-image.tar.gz gs://liftoff-dev-source


### PR DESCRIPTION
Shrinks deployments from > 7Mb to < 1 Mb

TBR @danrubel 