### PR TITLE
Type of map return -> dynamic

### DIFF
--- a/sintr_analysis_server_example/lib/query.dart
+++ b/sintr_analysis_server_example/lib/query.dart
@@ -21,7 +21,7 @@ abstract class Mapper {
 
   /// Process the given message and return a result, which may be `null`.
   /// Subtypes must implement this method.
-  String map(String message);
+  dynamic map(String message);
 
   /// Perform cleanup and return any remaining results.
   /// Subtypes may override this method.

--- a/sintr_analysis_server_example/lib/query.dart
+++ b/sintr_analysis_server_example/lib/query.dart
@@ -25,5 +25,5 @@ abstract class Mapper {
 
   /// Perform cleanup and return any remaining results.
   /// Subtypes may override this method.
-  List<String> cleanup() => [];
+  List cleanup() => [];
 }


### PR DESCRIPTION
@danrubel The mapper shouldn't constrain the return type to a String, e.g. if you look at the results of the other queries in e.g. perf, they're returning lists.

Ultimately the return type here needs to be something along the lines of

```
List<MapResult> map()

class MapResult {
  String Key;
  Object Value_That_Can_Be_JSON_Encoded
}
```

I'm concerned however from past experience using a system that did this that it results in code that is horrible to read, where the majority of the code doing the work is hidden the object boxing and unboxing code. Not quite sure yet what I want us to do here, but we certainly need to be able to provide structured objects out as the result.