### PR TITLE
completion metric - add 95th % calc and update response time buckets

### DIFF
--- a/sintr_analysis_server_example/lib/instrumentation_query.dart
+++ b/sintr_analysis_server_example/lib/instrumentation_query.dart
@@ -106,7 +106,6 @@ void updateBucket(Map<int, int> buckets, int value,
     {List<int> limits: const [0, 1, 5, 25, 50]}) {
   var limitIter = limits.iterator..moveNext();
   int limit = limitIter.current;
-  int lastIndex = 0;
   while (limit < value) {
     buckets.putIfAbsent(limit, () => 0);
     limit = limitIter.moveNext() ? limitIter.current : limit * 2;

--- a/sintr_analysis_server_example/lib/instrumentation_transformer.dart
+++ b/sintr_analysis_server_example/lib/instrumentation_transformer.dart
@@ -68,8 +68,6 @@ class _LogItemSink extends StringConversionSinkBase {
 
   /// `true` if non-sequential message blocks should be tolerated
   /// or `false` if an exception should be thrown.
-  /// If `true` then [hasNonSequentialMsgs] will be set `true`
-  /// if a non sequential block is found.
   bool allowNonSequentialMsgs;
 
   /// The number of missing messages.

--- a/sintr_analysis_server_example/lib/query/completion_metrics.dart
+++ b/sintr_analysis_server_example/lib/query/completion_metrics.dart
@@ -39,6 +39,7 @@ final completionReducer = (String sdkVersion, List extracted, Map results) {
     sdkResults = {
       VERSION: sdkVersion,
       RESPONSE_TIMES: [],
+      RESPONSE_TIME_BUCKETS: {},
       RESULT_COUNTS: [],
       TOTAL: 0,
       //MIN: 0,
@@ -58,6 +59,8 @@ final completionReducer = (String sdkVersion, List extracted, Map results) {
     sdkResults[TOTAL] += completionTime;
     sdkResults[MIN] = _min(sdkResults[MIN], completionTime);
     sdkResults[MAX] = _max(sdkResults[MAX], completionTime);
+    updateBucket(sdkResults[RESPONSE_TIME_BUCKETS], completionTime,
+        limits: [0, 1, 5, 10, 20, 30, 40, 50, 100, 150, 200, 250]);
     updateCalculations(sdkResults);
   } else {
     ++sdkResults[INCOMPLETE];
@@ -85,6 +88,9 @@ final completionReductionMerge = (Map results1, Map results2) {
       var sdkResults = {
         VERSION: key,
         RESPONSE_TIMES: values,
+        RESPONSE_TIME_BUCKETS: mergeBucketsRecursively(
+            sdkResults1[RESPONSE_TIME_BUCKETS],
+            sdkResults2[RESPONSE_TIME_BUCKETS]),
         RESULT_COUNTS: counts,
         TOTAL: total,
         MIN: _min(sdkResults1[MIN], sdkResults2[MIN]),
@@ -111,7 +117,6 @@ void updateCalculations(sdkResults) {
   sdkResults[V90TH] = values[(values.length * (9 / 10)).floor()];
   sdkResults[V95TH] = values[(values.length * (95 / 100)).floor()];
   sdkResults[V99TH] = values[(values.length * (99 / 100)).floor()];
-  sdkResults[RESPONSE_TIME_BUCKETS] = _gatherIntoBuckets(values, [32]);
   var counts = sdkResults[RESULT_COUNTS];
   sdkResults[RESULT_COUNT_BUCKETS] = _gatherIntoBuckets(counts, [0, 1, 5, 50]);
 }

--- a/sintr_analysis_server_example/lib/query/completion_metrics.dart
+++ b/sintr_analysis_server_example/lib/query/completion_metrics.dart
@@ -23,6 +23,7 @@ const RESULT_COUNT_BUCKETS = 'resultCountBuckets';
 const RESULT_COUNTS = 'resultCounts';
 const TOTAL = 'total';
 const V90TH = '90th';
+const V95TH = '95th';
 const V99TH = '99th';
 const VERSION = 'version';
 
@@ -108,6 +109,7 @@ void updateCalculations(sdkResults) {
   List<int> values = sdkResults[RESPONSE_TIMES];
   sdkResults[AVE] = sdkResults[TOTAL] / values.length;
   sdkResults[V90TH] = values[(values.length * (9 / 10)).floor()];
+  sdkResults[V95TH] = values[(values.length * (95 / 100)).floor()];
   sdkResults[V99TH] = values[(values.length * (99 / 100)).floor()];
   sdkResults[RESPONSE_TIME_BUCKETS] = _gatherIntoBuckets(values, [32]);
   var counts = sdkResults[RESULT_COUNTS];

--- a/sintr_analysis_server_example/lib/query/completion_metrics.dart
+++ b/sintr_analysis_server_example/lib/query/completion_metrics.dart
@@ -4,14 +4,10 @@
 
 library sintr_worker_lib.completion;
 
-import 'dart:async';
 import 'dart:convert';
-import 'dart:math';
 
 import 'package:sintr_worker_lib/instrumentation_query.dart';
 import 'package:sintr_worker_lib/instrumentation_transformer.dart';
-import 'package:sintr_worker_lib/query.dart';
-import 'package:sintr_worker_lib/session_info.dart';
 
 const AVE = 'ave';
 const INCOMPLETE = 'incomplete';

--- a/sintr_analysis_server_example/lib/query/perf.dart
+++ b/sintr_analysis_server_example/lib/query/perf.dart
@@ -20,9 +20,11 @@ final apiUsageReducer = (String sdkVersion, List perfData, Map results) {
   var perfName = perfData[3];
 
   // Record number of requests of each type per SDK
-  Map sdkResults = results.putIfAbsent(sdkVersion, () => {});
-  sdkResults.putIfAbsent(perfName, () => 0);
-  ++sdkResults[perfName];
+  if (perfType == REQUEST_PERF) {
+    Map sdkResults = results.putIfAbsent(sdkVersion, () => {});
+    sdkResults.putIfAbsent(perfName, () => 0);
+    ++sdkResults[perfName];
+  }
 
   return results;
 };

--- a/sintr_analysis_server_example/lib/query/perf.dart
+++ b/sintr_analysis_server_example/lib/query/perf.dart
@@ -28,7 +28,7 @@ final apiUsageReducer = (String sdkVersion, List perfData, Map results) {
 };
 
 /// Merge two sets of results
-final apiUsageReductionMerge = perfReductionMerge;
+final apiUsageReductionMerge = mergeBucketsRecursively;
 
 /// Add an extraction result to the overall performance [results]
 /// where [extracted] is provided by [PerfMapper].
@@ -47,49 +47,12 @@ final perfReducer = (String sdkVersion, List perfData, Map results) {
   Map perfResults = perfTypeResults.putIfAbsent(perfName, () => {});
 
   // Update current results
-  _updateBucket(perfResults, elapsedTime);
+  updateBucket(perfResults, elapsedTime);
   return results;
 };
 
 /// Merge two sets of results
-final perfReductionMerge = (Map results1, Map results2) {
-  Map results = {};
-  results1.forEach((key, value1) {
-    var value2 = results2[key];
-    if (value2 == null) {
-      results[key] = value1;
-    } else if (value1 is Map) {
-      results[key] = perfReductionMerge(value1, value2);
-    } else {
-      results[key] = value1 + value2;
-    }
-  });
-  results2.forEach((key, value2) {
-    var value1 = results1[key];
-    if (value1 == null) {
-      results[key] = value2;
-    }
-  });
-  return results;
-};
-
-/// Increment the count in the bucket containing [value]
-/// where [limits] are the bounds used for the initial set of buckets.
-/// Any values beyond the last bound specified in [limits]
-/// are placed into buckets of size increasing by a multiple of 2
-/// times the last bucket bounds.
-void _updateBucket(Map<int, int> buckets, int value,
-    {List<int> limits: const [0, 1, 5, 25, 50]}) {
-  var limitIter = limits.iterator..moveNext();
-  int limit = limitIter.current;
-  int lastIndex = 0;
-  while (limit < value) {
-    buckets.putIfAbsent(limit, () => 0);
-    limit = limitIter.moveNext() ? limitIter.current : limit * 2;
-  }
-  buckets.putIfAbsent(limit, () => 0);
-  ++buckets[limit];
-}
+final perfReductionMerge = mergeBucketsRecursively;
 
 /// [PerfMapper] processes session messages and extracts 'Perf' entries
 /// along with request/response pair performance.

--- a/sintr_analysis_server_example/lib/query/session_ldap.dart
+++ b/sintr_analysis_server_example/lib/query/session_ldap.dart
@@ -4,13 +4,9 @@
 
 library sintr_worker_lib.session_ldap;
 
-import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:sintr_worker_lib/instrumentation_query.dart';
-import 'package:sintr_worker_lib/query.dart';
-import 'package:sintr_worker_lib/session_info.dart';
 
 final sessionIdComparator = (String s1, String s2) =>
     double.parse(s1) - double.parse(s2);

--- a/sintr_analysis_server_example/test/query/completion_metrics_test.dart
+++ b/sintr_analysis_server_example/test/query/completion_metrics_test.dart
@@ -14,11 +14,11 @@ main() {
 
     results = completionReducer('sdk1', [24, 99], results);
     expect(results, hasLength(1));
-    _expectSdkResults(results['sdk1'], 24, 24, 24, 24, 24, 0);
+    _expectSdkResults(results['sdk1'], 24, 24, 24, 24, 24, 24, 0);
 
     results = completionReducer('sdk1', [12, 99], results);
     expect(results, hasLength(1));
-    _expectSdkResults(results['sdk1'], 12, 24, 18, 24, 24, 0);
+    _expectSdkResults(results['sdk1'], 12, 24, 18, 24, 24, 24, 0);
 
     var newValues = [];
     for (int count = 2; count <= 100; ++count) {
@@ -29,23 +29,23 @@ main() {
       results = completionReducer('sdk1', [value, 99], results);
     });
     expect(results, hasLength(1));
-    _expectSdkResults(results['sdk1'], 12, 200, 148, 190, 199, 0);
+    _expectSdkResults(results['sdk1'], 12, 200, 148, 190, 195, 199, 0);
 
     newValues.shuffle();
     newValues.forEach((value) {
       results = completionReducer('sdk1', [value, 99], results);
     });
     expect(results, hasLength(1));
-    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 200, 0);
+    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 196,  200, 0);
 
     results = completionReducer('sdk1', [-1, 0], results);
     expect(results, hasLength(1));
-    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 200, 1);
+    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 196, 200, 1);
 
     results = completionReducer('sdk2', [27, 99], results);
     expect(results, hasLength(2));
-    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 200, 1);
-    _expectSdkResults(results['sdk2'], 27, 27, 27, 27, 27, 0);
+    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 196, 200, 1);
+    _expectSdkResults(results['sdk2'], 27, 27, 27, 27, 27, 27, 0);
   });
 
   test('completionReductionMerge', () {
@@ -53,24 +53,24 @@ main() {
 
     results1 = _merge(results1, 'sdk1', 12);
     expect(results1, hasLength(1));
-    _expectSdkResults(results1['sdk1'], 12, 12, 12, 12, 12, 0);
+    _expectSdkResults(results1['sdk1'], 12, 12, 12, 12, 12, 12, 0);
 
     results1 = _merge(results1, 'sdk1', 24);
     expect(results1, hasLength(1));
-    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 0);
+    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 0);
 
     results1 = _merge(results1, 'sdk1', -1);
     expect(results1, hasLength(1));
-    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 1);
+    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 1);
 
     results1 = _merge(results1, 'sdk1', -2);
     expect(results1, hasLength(1));
-    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 2);
+    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 2);
 
     results1 = _merge(results1, 'sdk2', 27);
     expect(results1, hasLength(2));
-    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 2);
-    _expectSdkResults(results1['sdk2'], 27, 27, 27, 27, 27, 0);
+    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 2);
+    _expectSdkResults(results1['sdk2'], 27, 27, 27, 27, 27, 27, 0);
 
     Map<String, Map<String, dynamic>> results2 = {};
 
@@ -83,22 +83,22 @@ main() {
       results2 = _merge(results2, 'sdk1', value);
     });
     expect(results2, hasLength(1));
-    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 200, 0);
+    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 196, 200, 0);
 
     results2 = _merge(results2, 'sdk1', -2);
     expect(results2, hasLength(1));
-    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 200, 1);
+    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 196, 200, 1);
 
     results2 = _merge(results2, 'sdk3', 82);
     expect(results2, hasLength(2));
-    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 200, 1);
-    _expectSdkResults(results2['sdk3'], 82, 82, 82, 82, 82, 0);
+    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 196, 200, 1);
+    _expectSdkResults(results2['sdk3'], 82, 82, 82, 82, 82, 82, 0);
 
     var results = completionReductionMerge(results1, results2);
     expect(results, hasLength(3));
-    _expectSdkResults(results['sdk1'], 12, 200, 148, 190, 199, 3);
-    _expectSdkResults(results['sdk2'], 27, 27, 27, 27, 27, 0);
-    _expectSdkResults(results['sdk3'], 82, 82, 82, 82, 82, 0);
+    _expectSdkResults(results['sdk1'], 12, 200, 148, 190, 195, 199, 3);
+    _expectSdkResults(results['sdk2'], 27, 27, 27, 27, 27, 27, 0);
+    _expectSdkResults(results['sdk3'], 82, 82, 82, 82, 82, 82, 0);
   });
 
   test('updateCalculations', () {
@@ -150,7 +150,7 @@ main() {
 }
 
 void _expectSdkResults(Map<String, dynamic> sdkResults, int min, int max,
-    int ave, int v90th, int v99th, int incomplete) {
+    int ave, int v90th, int v95th, int v99th, int incomplete) {
   verifySorted(sdkResults[RESPONSE_TIMES]);
   verifySorted(sdkResults[RESULT_COUNTS]);
   expect(sdkResults[RESPONSE_TIMES].length, sdkResults[RESULT_COUNTS].length);
@@ -158,6 +158,7 @@ void _expectSdkResults(Map<String, dynamic> sdkResults, int min, int max,
   expect(sdkResults[MAX], max);
   expect(sdkResults[AVE].round(), ave);
   expect(sdkResults[V90TH], v90th);
+  expect(sdkResults[V95TH], v95th);
   expect(sdkResults[V99TH], v99th);
   expect(sdkResults[INCOMPLETE], incomplete);
 }

--- a/sintr_analysis_server_example/test/query/completion_metrics_test.dart
+++ b/sintr_analysis_server_example/test/query/completion_metrics_test.dart
@@ -14,11 +14,15 @@ main() {
 
     results = completionReducer('sdk1', [24, 99], results);
     expect(results, hasLength(1));
-    _expectSdkResults(results['sdk1'], 24, 24, 24, 24, 24, 24, 0);
+    _expectSdkResults(results['sdk1'], 24, 24, 24, 24, 24, 24, 0,
+      expectedResponseTimeBuckets: {
+        0:0, 1:0, 5:0, 10:0, 20:0, 30:1});
 
     results = completionReducer('sdk1', [12, 99], results);
     expect(results, hasLength(1));
-    _expectSdkResults(results['sdk1'], 12, 24, 18, 24, 24, 24, 0);
+    _expectSdkResults(results['sdk1'], 12, 24, 18, 24, 24, 24, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1, 30:1});
 
     var newValues = [];
     for (int count = 2; count <= 100; ++count) {
@@ -29,23 +33,33 @@ main() {
       results = completionReducer('sdk1', [value, 99], results);
     });
     expect(results, hasLength(1));
-    _expectSdkResults(results['sdk1'], 12, 200, 148, 190, 195, 199, 0);
+    _expectSdkResults(results['sdk1'], 12, 200, 148, 190, 195, 199, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1, 30:1, 40:0, 50:0, 100:0, 150:49, 200:50});
 
     newValues.shuffle();
     newValues.forEach((value) {
       results = completionReducer('sdk1', [value, 99], results);
     });
     expect(results, hasLength(1));
-    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 196,  200, 0);
+    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 196,  200, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1, 30:1, 40:0, 50:0, 100:0, 150:98, 200:100});
 
     results = completionReducer('sdk1', [-1, 0], results);
     expect(results, hasLength(1));
-    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 196, 200, 1);
+    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 196, 200, 1,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1, 30:1, 40:0, 50:0, 100:0, 150:98, 200:100});
 
     results = completionReducer('sdk2', [27, 99], results);
     expect(results, hasLength(2));
-    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 196, 200, 1);
-    _expectSdkResults(results['sdk2'], 27, 27, 27, 27, 27, 27, 0);
+    _expectSdkResults(results['sdk1'], 12, 200, 150, 191, 196, 200, 1,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1, 30:1, 40:0, 50:0, 100:0, 150:98, 200:100});
+    _expectSdkResults(results['sdk2'], 27, 27, 27, 27, 27, 27, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:0, 30:1});
   });
 
   test('completionReductionMerge', () {
@@ -53,24 +67,36 @@ main() {
 
     results1 = _merge(results1, 'sdk1', 12);
     expect(results1, hasLength(1));
-    _expectSdkResults(results1['sdk1'], 12, 12, 12, 12, 12, 12, 0);
+    _expectSdkResults(results1['sdk1'], 12, 12, 12, 12, 12, 12, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1});
 
     results1 = _merge(results1, 'sdk1', 24);
     expect(results1, hasLength(1));
-    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 0);
+    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1, 30:1});
 
     results1 = _merge(results1, 'sdk1', -1);
     expect(results1, hasLength(1));
-    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 1);
+    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 1,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1, 30:1});
 
     results1 = _merge(results1, 'sdk1', -2);
     expect(results1, hasLength(1));
-    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 2);
+    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 2,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1, 30:1});
 
     results1 = _merge(results1, 'sdk2', 27);
     expect(results1, hasLength(2));
-    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 2);
-    _expectSdkResults(results1['sdk2'], 27, 27, 27, 27, 27, 27, 0);
+    _expectSdkResults(results1['sdk1'], 12, 24, 18, 24, 24, 24, 2,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1, 30:1});
+    _expectSdkResults(results1['sdk2'], 27, 27, 27, 27, 27, 27, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:0, 30:1});
 
     Map<String, Map<String, dynamic>> results2 = {};
 
@@ -83,22 +109,36 @@ main() {
       results2 = _merge(results2, 'sdk1', value);
     });
     expect(results2, hasLength(1));
-    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 196, 200, 0);
+    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 196, 200, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:0, 30:0, 40:0, 50:0, 100:0, 150:49, 200:50});
 
     results2 = _merge(results2, 'sdk1', -2);
     expect(results2, hasLength(1));
-    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 196, 200, 1);
+    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 196, 200, 1,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:0, 30:0, 40:0, 50:0, 100:0, 150:49, 200:50});
 
     results2 = _merge(results2, 'sdk3', 82);
     expect(results2, hasLength(2));
-    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 196, 200, 1);
-    _expectSdkResults(results2['sdk3'], 82, 82, 82, 82, 82, 82, 0);
+    _expectSdkResults(results2['sdk1'], 102, 200, 151, 191, 196, 200, 1,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:0, 30:0, 40:0, 50:0, 100:0, 150:49, 200:50});
+    _expectSdkResults(results2['sdk3'], 82, 82, 82, 82, 82, 82, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:0, 30:0, 40:0, 50:0, 100:1});
 
     var results = completionReductionMerge(results1, results2);
     expect(results, hasLength(3));
-    _expectSdkResults(results['sdk1'], 12, 200, 148, 190, 195, 199, 3);
-    _expectSdkResults(results['sdk2'], 27, 27, 27, 27, 27, 27, 0);
-    _expectSdkResults(results['sdk3'], 82, 82, 82, 82, 82, 82, 0);
+    _expectSdkResults(results['sdk1'], 12, 200, 148, 190, 195, 199, 3,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:1, 30:1, 40:0, 50:0, 100:0, 150:49, 200:50});
+    _expectSdkResults(results['sdk2'], 27, 27, 27, 27, 27, 27, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:0, 30:1});
+    _expectSdkResults(results['sdk3'], 82, 82, 82, 82, 82, 82, 0,
+        expectedResponseTimeBuckets: {
+          0:0, 1:0, 5:0, 10:0, 20:0, 30:0, 40:0, 50:0, 100:1});
   });
 
   test('updateCalculations', () {
@@ -130,15 +170,8 @@ main() {
     updateCalculations(sdkResults);
     expect(sdkResults[AVE].round(), 54);
     expect(sdkResults[V90TH], 290);
+    expect(sdkResults[V95TH], 387);
     expect(sdkResults[V99TH], 694);
-    Map<int, int> values = sdkResults[RESPONSE_TIME_BUCKETS];
-    expect(values, hasLength(6));
-    expect(values[32], 241);
-    expect(values[64], 21);
-    expect(values[128], 2);
-    expect(values[256], 0);
-    expect(values[512], 27);
-    expect(values[1024], 5);
     Map<int, int> counts = sdkResults[RESULT_COUNT_BUCKETS];
     expect(counts, hasLength(5));
     expect(counts[0], 4);
@@ -150,7 +183,8 @@ main() {
 }
 
 void _expectSdkResults(Map<String, dynamic> sdkResults, int min, int max,
-    int ave, int v90th, int v95th, int v99th, int incomplete) {
+    int ave, int v90th, int v95th, int v99th, int incomplete,
+    {Map<int, int> expectedResponseTimeBuckets}) {
   verifySorted(sdkResults[RESPONSE_TIMES]);
   verifySorted(sdkResults[RESULT_COUNTS]);
   expect(sdkResults[RESPONSE_TIMES].length, sdkResults[RESULT_COUNTS].length);
@@ -161,6 +195,7 @@ void _expectSdkResults(Map<String, dynamic> sdkResults, int min, int max,
   expect(sdkResults[V95TH], v95th);
   expect(sdkResults[V99TH], v99th);
   expect(sdkResults[INCOMPLETE], incomplete);
+  expect(sdkResults[RESPONSE_TIME_BUCKETS], equals(expectedResponseTimeBuckets));
 }
 
 _merge(Map<String, Map<String, dynamic>> results, String sdkVersion,


### PR DESCRIPTION
@lukechurch 
- calc 95th % completion result metrics
- extract bucket functions from perf query for use in completion query
- update bucket limits for completion query
- cleanup analysis hints
- fix apiUsageReducer to only record request counts
