### PR TITLE
Run Workers in Zones

### DIFF
--- a/sintr_analysis_server_example/worker_isolate.dart
+++ b/sintr_analysis_server_example/worker_isolate.dart
@@ -28,7 +28,7 @@ Future main(List<String> args, SendPort sendPort) async {
 }
 
 Future<String> _protectedHandle(String msg) async {
-  try {
+  return runZoned(() async {
     var inputData = JSON.decode(msg);
     String bucketName = inputData[0];
     String objectPath = inputData[1];
@@ -92,11 +92,11 @@ Future<String> _protectedHandle(String msg) async {
       "linesProcessed": lines,
       "input": "gs://$bucketName/$objectPath"
     });
-  } catch (e, st) {
+  }, onError: (e, st) {
     log.info("Message proc erred. $e \n $st \n");
     log.debug("Input data: $msg");
     return JSON.encode({"error": "${e}", "stackTrace": "${st}"});
-  }
+  });
 }
 
 Future<Stream<List<int>>> getDataFromCloud(


### PR DESCRIPTION
Some async exceptions from Cloud Storage were causing worker tear down. It's not a huge problem as the error management infrastructure will restart it, but better to catch it here.

@danrubel 
